### PR TITLE
fix a bug in DDPG.py.

### DIFF
--- a/contents/9_Deep_Deterministic_Policy_Gradient_DDPG/DDPG.py
+++ b/contents/9_Deep_Deterministic_Policy_Gradient_DDPG/DDPG.py
@@ -138,7 +138,7 @@ class Critic(object):
             self.train_op = tf.train.AdamOptimizer(self.lr).minimize(self.loss)
 
         with tf.variable_scope('a_grad'):
-            self.a_grads = tf.gradients(self.q, a)[0]   # tensor of gradients of each sample (None, a_dim)
+            self.a_grads = tf.gradients(self.q, self.a)[0]   # tensor of gradients of each sample (None, a_dim)
 
         if self.replacement['name'] == 'hard':
             self.t_replace_counter = 0


### PR DESCRIPTION
if you use `a` in the program, the gradient will always be `None`.